### PR TITLE
parameter rules

### DIFF
--- a/velin2/context.py
+++ b/velin2/context.py
@@ -6,4 +6,5 @@ class Context:
     path = attrs.field()
 
     docstring_node = attrs.field()
+    parent_node = attrs.field()
     column_offsets = attrs.field()

--- a/velin2/main.py
+++ b/velin2/main.py
@@ -13,7 +13,10 @@ def process_file(path):
 
     tree = parser.parse(path.read_bytes())
     docstring_nodes = extract_docstring_nodes(tree)
-    violations = [check_docstring(path, node) for node in docstring_nodes]
+    violations = [
+        check_docstring(path, docstring, parent)
+        for docstring, parent in docstring_nodes
+    ]
 
     return len(violations), format_report(violations)
 

--- a/velin2/python.py
+++ b/velin2/python.py
@@ -22,3 +22,30 @@ def extract_docstring_nodes(tree):
     docstrings = [extract_string(node) for node in captures.get("docstring", [])]
 
     return zip(docstrings, parents)
+
+
+def extract_identifier(node):
+    if node.type in {"identifier", "list_splat_pattern", "dictionary_splat_pattern"}:
+        return node
+
+    return node.child_by_field_name("name")
+
+
+def extract_parameter_names(node):
+    parameter_field = node.child_by_field_name("parameters")
+
+    identifier_types = {
+        "identifier",
+        "list_splat_pattern",
+        "dictionary_splat_pattern",
+        "default_parameter",
+        "typed_default_parameter",
+    }
+
+    identifiers = [
+        extract_identifier(node)
+        for node in parameter_field.children
+        if node.type in identifier_types
+    ]
+
+    return identifiers

--- a/velin2/python.py
+++ b/velin2/python.py
@@ -11,11 +11,14 @@ def extract_docstring_nodes(tree):
         (module . (comment)+ (expression_statement (string) @docstring))
         (function_definition (block . (expression_statement (string) @docstring)))
         (class_definition (block . (expression_statement (string) @docstring)))
-      ]
+      ] @parent
     """
     lang_py = get_language("python")
 
     query = lang_py.query(query_statement)
-    return [
-        extract_string(node) for node in query.captures(tree.root_node)["docstring"]
-    ]
+    captures = query.captures(tree.root_node)
+    parents = captures.get("parent", [])
+
+    docstrings = [extract_string(node) for node in captures.get("docstring", [])]
+
+    return zip(docstrings, parents)

--- a/velin2/rules/__init__.py
+++ b/velin2/rules/__init__.py
@@ -1,2 +1,2 @@
-from velin2.rules import sections  # noqa: F401
+from velin2.rules import parameters, sections  # noqa: F401
 from velin2.rules.core import check_docstring  # noqa: F401

--- a/velin2/rules/core.py
+++ b/velin2/rules/core.py
@@ -63,9 +63,14 @@ def _check_docstring(tree, context):
     return violations
 
 
-def check_docstring(path, node):
-    cleaned_docstring, column_offsets = cleandoc(node.text.decode())
-    context = Context(path, node, column_offsets)
+def check_docstring(path, docstring, parent):
+    cleaned_docstring, column_offsets = cleandoc(docstring.text.decode())
+    context = Context(
+        path,
+        docstring_node=docstring,
+        parent_node=parent,
+        column_offsets=column_offsets,
+    )
     tree = parser_rst.parse(cleaned_docstring.encode())
 
     return _check_docstring(tree, context)

--- a/velin2/rules/parameters.py
+++ b/velin2/rules/parameters.py
@@ -53,7 +53,15 @@ def custom_predicates(predicate, args, pattern_index, captures):
 
             nodes = captures[values[0]]
 
-            return any(not node.text.decode().isidentifier() for node in nodes)
+            return any(
+                not (
+                    node.text.decode()
+                    .removeprefix("**")
+                    .removeprefix("*")
+                    .isidentifier()
+                )
+                for node in nodes
+            )
 
     raise TypeError(f"unknown predicate: {predicate}")
 

--- a/velin2/rules/parameters.py
+++ b/velin2/rules/parameters.py
@@ -1,20 +1,59 @@
 from velin2.rules.core import lang_rst, register_rule
 
+query_parameters = """
+(
+  section (title) @title
+  (#any-of? @title "Parameters" "Other Parameters")
+)
+"""
+
+
+def format_type(type_):
+    return type_ if type_ != "capture" else "capture name"
+
+
+def validate_parameter_types(types_, expected_types, predicate):
+    if types_ == expected_types:
+        return
+
+    if len(expected_types) == 1:
+        type_names = map(format_type, types_)
+        expected_type_name = format_type(expected_types[0])
+
+        msg = (
+            f"predicate {predicate} requires exactly one {expected_type_name}."
+            f" Got [{', '.join(type_names)}] instead."
+        )
+    else:
+        type_names = map(format_type, types_)
+        expected_type_names = map(format_type, expected_types)
+        msg = (
+            "Unexpected argument types."
+            f" Expected [{', '.join(expected_type_names)}],"
+            f" but got [{', '.join(type_names)}]."
+        )
+
+    raise TypeError(msg)
+
 
 def custom_predicates(predicate, args, pattern_index, captures):
+    types_ = [type_ for _, type_ in args]
+    values = [value for value, _ in args]
     match predicate:
         case "not-definition-list?":
-            if len(args) != 1 or (type_ := args[0][1]) != "capture":
-                type_name = type_ if type_ != "capture" else "capture name"
-                raise TypeError(
-                    f"predicate {predicate} requires exactly one capture name."
-                    f" Got {args[0][0]} (a {type_name}) instead."
-                )
+            validate_parameter_types(types_, ["capture"], predicate)
 
             # query guarantees that the capture name exists
-            nodes = captures[args[0][0]]
+            nodes = captures[values[0]]
 
-            return all(node.type != "definition_list" for node in nodes)
+            return any(node.type != "definition_list" for node in nodes)
+
+        case "python-identifier?":
+            validate_parameter_types(types_, ["capture"], predicate)
+
+            nodes = captures[values[0]]
+
+            return any(not node.text.decode().isidentifier() for node in nodes)
 
     raise TypeError(f"unknown predicate: {predicate}")
 
@@ -24,14 +63,10 @@ def custom_predicates(predicate, args, pattern_index, captures):
     "Parameters must be formatted as a definition list",
 )
 def check_format_as_definition_list(tree, context):
-    # '((section (title) @title (#eq? @title "Parameters")) (_)+ @content)'
     query = lang_rst.query(
-        """
+        f"""
         (
-          (
-            section (title) @title
-            (#any-of? @title "Parameters" "Other Parameters")
-          )
+          {query_parameters}
           .
           ((_) @node (#not-definition-list? @node)) @content
         )
@@ -42,4 +77,30 @@ def check_format_as_definition_list(tree, context):
 
     violations = [node for node in result.get("content", [])]
     suggestions = [_ for _ in violations]
+    return zip(violations, suggestions)
+
+
+@register_rule(
+    "V110",
+    "Listed parameters must be valid python identifiers.",
+)
+def check_term_is_a_python_identifier(tree, context):
+    query = lang_rst.query(
+        f"""
+        (
+          {query_parameters}
+          .
+          (
+            definition_list
+            (list_item (term) @term (#python-identifier? @term))
+          )
+        )
+        """
+    )
+
+    result = query.captures(tree.root_node, predicate=custom_predicates)
+
+    violations = [node for node in result.get("term", [])]
+    suggestions = [_ for _ in violations]
+
     return zip(violations, suggestions)

--- a/velin2/rules/parameters.py
+++ b/velin2/rules/parameters.py
@@ -1,0 +1,42 @@
+from velin2.rules.core import lang_rst, register_rule
+
+
+def custom_predicates(predicate, args, pattern_index, captures):
+    match predicate:
+        case "not-definition-list?":
+            if len(args) != 1 or (type_ := args[0][1]) != "capture":
+                type_name = type_ if type_ != "capture" else "capture name"
+                raise TypeError(
+                    f"predicate {predicate} requires exactly one capture name."
+                    f" Got {args[0][0]} (a {type_name}) instead."
+                )
+
+            # query guarantees that the capture name exists
+            nodes = captures[args[0][0]]
+
+            return all(node.type == "definition_list" for node in nodes)
+
+    raise TypeError(f"unknown predicate: {predicate}")
+
+
+@register_rule(
+    "V100",
+    "Parameters must be formatted as a definition list",
+)
+def check_format_as_definition_list(tree, context):
+    # '((section (title) @title (#eq? @title "Parameters")) (_)+ @content)'
+    query = lang_rst.query(
+        """
+        (
+          (section (title) @title (#eq? @title "Parameters"))
+          .
+          (_) @node (#not-definition-list? @node)
+        ) @content
+        """
+    )
+
+    result = query.captures(tree.root_node, predicate=custom_predicates)
+
+    violations = [node for node in result.get("content", [])]
+    suggestions = [_ for _ in violations]
+    return zip(violations, suggestions)

--- a/velin2/rules/parameters.py
+++ b/velin2/rules/parameters.py
@@ -28,7 +28,10 @@ def check_format_as_definition_list(tree, context):
     query = lang_rst.query(
         """
         (
-          (section (title) @title (#eq? @title "Parameters"))
+          (
+            section (title) @title
+            (#any-of? @title "Parameters" "Other Parameters")
+          )
           .
           ((_) @node (#not-definition-list? @node)) @content
         )

--- a/velin2/rules/parameters.py
+++ b/velin2/rules/parameters.py
@@ -14,7 +14,7 @@ def custom_predicates(predicate, args, pattern_index, captures):
             # query guarantees that the capture name exists
             nodes = captures[args[0][0]]
 
-            return all(node.type == "definition_list" for node in nodes)
+            return all(node.type != "definition_list" for node in nodes)
 
     raise TypeError(f"unknown predicate: {predicate}")
 
@@ -30,8 +30,8 @@ def check_format_as_definition_list(tree, context):
         (
           (section (title) @title (#eq? @title "Parameters"))
           .
-          (_) @node (#not-definition-list? @node)
-        ) @content
+          ((_) @node (#not-definition-list? @node)) @content
+        )
         """
     )
 

--- a/velin2/rules/sections.py
+++ b/velin2/rules/sections.py
@@ -60,7 +60,7 @@ def check_blank_line_before_section(tree, context):
         return matching_children
 
     query = lang_rst.query("[(paragraph) (term) (ERROR)] @node")
-    nodes = [node for node in query.captures(tree.root_node)["node"]]
+    nodes = query.captures(tree.root_node).get("node", [])
 
     violations = list(
         itertools.chain.from_iterable(find_section_nodes(node) for node in nodes)
@@ -81,7 +81,7 @@ def check_blank_line_before_section(tree, context):
 )
 def check_section_name(tree, context):
     query = lang_rst.query("(section (title) @title)")
-    titles = [node for node in query.captures(tree.root_node)["title"]]
+    titles = query.captures(tree.root_node).get("title", [])
 
     violations = [
         title for title in titles if title.text.decode() not in valid_section_names
@@ -106,9 +106,10 @@ def check_section_name(tree, context):
 def check_section_order(tree, context):
     def extract_sections(tree):
         query = lang_rst.query("(document [(paragraph) (directive)] @section)")
-        unnamed_sections = [node for node in query.captures(tree.root_node)["section"]]
+        unnamed_sections = query.captures(tree.root_node).get("section", [])
+
         query = lang_rst.query("(section) @section")
-        named_sections = [node for node in query.captures(tree.root_node)["section"]]
+        named_sections = query.captures(tree.root_node).get("section", [])
 
         return unnamed_sections, named_sections
 
@@ -144,7 +145,7 @@ def check_section_order(tree, context):
                     unnamed_names["extended_summary"] = extended + [node]
             elif node.type == "directive":
                 query = lang_rst.query("(type) @type")
-                [type_node] = query.captures(node)["type"]
+                [type_node] = query.captures(node).get("type", [])
                 type_ = type_node.text.decode()
                 if type_ != "deprecated":
                     pass
@@ -197,7 +198,7 @@ def check_section_order(tree, context):
 def check_section_adornment_position(tree, context):
     """section titles must have only an underline"""
     query = lang_rst.query("(section) @section")
-    sections = [node for node in query.captures(tree.root_node)["section"]]
+    sections = query.captures(tree.root_node).get("section", [])
 
     violations = [
         node
@@ -215,7 +216,7 @@ def check_section_adornment_position(tree, context):
 def check_section_adornment_length(tree, context):
     """section adornment must have the same length as the title"""
     query = lang_rst.query("(section) @section")
-    sections = [node for node in query.captures(tree.root_node)["section"]]
+    sections = query.captures(tree.root_node).get("section", [])
 
     violations = [
         node.child(1)
@@ -233,7 +234,7 @@ def check_section_adornment_length(tree, context):
 def check_section_adornment(tree, context):
     """section adornment must consist only of '-'"""
     query = lang_rst.query("(section) @section")
-    sections = [node for node in query.captures(tree.root_node)["section"]]
+    sections = query.captures(tree.root_node).get("section", [])
 
     violations = [
         node

--- a/velin2/tests/__init__.py
+++ b/velin2/tests/__init__.py
@@ -1,0 +1,12 @@
+class DummyNode:
+    def __init__(self):
+        self.start_point = (0, 0)
+
+
+def format_violations(violations):
+    return "\n".join(
+        [
+            "Found the following violations:",
+            *(str(violation) for violation in violations),
+        ]
+    )

--- a/velin2/tests/conftest.py
+++ b/velin2/tests/conftest.py
@@ -1,0 +1,17 @@
+import pytest
+
+from velin2.rules import core
+
+
+@pytest.fixture
+def rules(monkeypatch):
+    class IsolatedRules:
+        def isolate(self, rules: str | list[str]):
+            if isinstance(rules, str):
+                rules = [rules]
+            isolated_rules = {
+                name: rule for name, rule in core.rules.items() if name in rules
+            }
+            monkeypatch.setattr(core, "rules", isolated_rules)
+
+    yield IsolatedRules()

--- a/velin2/tests/test_parameter_rules.py
+++ b/velin2/tests/test_parameter_rules.py
@@ -97,6 +97,10 @@ def test_format_as_definition_list(docstring, n_violations, rules):
             ----------
             a : int
                 description
+            *args
+                description
+            **kwargs
+                description
             """,
             0,
             id="parameters-passing",
@@ -116,6 +120,10 @@ def test_format_as_definition_list(docstring, n_violations, rules):
             Other Parameters
             ----------------
             a : int
+                description
+            *args
+                description
+            **kwargs
                 description
             """,
             0,

--- a/velin2/tests/test_parameter_rules.py
+++ b/velin2/tests/test_parameter_rules.py
@@ -18,7 +18,7 @@ from velin2.tests import DummyNode, format_violations
                 description
             """,
             0,
-            id="passing",
+            id="parameters-passing",
         ),
         pytest.param(
             """
@@ -28,7 +28,7 @@ from velin2.tests import DummyNode, format_violations
             b: text
             """,
             1,
-            id="failing-paragraph",
+            id="parameters-failing-paragraph",
         ),
         pytest.param(
             """
@@ -38,7 +38,38 @@ from velin2.tests import DummyNode, format_violations
             - b
             """,
             1,
-            id="failing-bullet_list",
+            id="parameters-failing-bullet_list",
+        ),
+        pytest.param(
+            """short summary
+
+            Other Parameters
+            ----------
+            a : int
+                description
+            """,
+            0,
+            id="other parameters-passing",
+        ),
+        pytest.param(
+            """
+            Other Parameters
+            ----------
+            a: text
+            b: text
+            """,
+            1,
+            id="other parameters-failing-paragraph",
+        ),
+        pytest.param(
+            """
+            Other Parameters
+            ----------
+            - a
+            - b
+            """,
+            1,
+            id="other parameters-failing-bullet_list",
         ),
     ),
 )

--- a/velin2/tests/test_parameter_rules.py
+++ b/velin2/tests/test_parameter_rules.py
@@ -86,3 +86,63 @@ def test_format_as_definition_list(docstring, n_violations, rules):
     violations = _check_docstring(tree, context)
 
     assert len(violations) == n_violations, format_violations(violations)
+
+
+@pytest.mark.parametrize(
+    ["docstring", "n_violations"],
+    (
+        pytest.param(
+            """
+            Parameters
+            ----------
+            a : int
+                description
+            """,
+            0,
+            id="parameters-passing",
+        ),
+        pytest.param(
+            """
+            Parameters
+            ----------
+            1a : int
+                description
+            """,
+            1,
+            id="parameters-failing",
+        ),
+        pytest.param(
+            """
+            Other Parameters
+            ----------------
+            a : int
+                description
+            """,
+            0,
+            id="other parameters-passing",
+        ),
+        pytest.param(
+            """
+            Other Parameters
+            ----------------
+            1a : int
+                description
+            """,
+            1,
+            id="other parameters-failing",
+        ),
+    ),
+)
+def test_term_is_a_python_identifier(docstring, n_violations, rules):
+    rules.isolate("V110")
+
+    dummy_node = DummyNode()
+
+    cleaned_docstring, column_offsets = cleandoc(docstring)
+
+    tree = parser_rst.parse(cleaned_docstring.encode())
+    context = Context("<test example>", dummy_node, column_offsets)
+
+    violations = _check_docstring(tree, context)
+
+    assert len(violations) == n_violations, format_violations(violations)

--- a/velin2/tests/test_parameter_rules.py
+++ b/velin2/tests/test_parameter_rules.py
@@ -1,0 +1,57 @@
+import pytest
+
+from velin2.context import Context
+from velin2.docstring import cleandoc
+from velin2.rules.core import _check_docstring, parser_rst
+from velin2.tests import DummyNode, format_violations
+
+
+@pytest.mark.parametrize(
+    ["docstring", "n_violations"],
+    (
+        pytest.param(
+            """short summary
+
+            Parameters
+            ----------
+            a : int
+                description
+            """,
+            0,
+            id="passing",
+        ),
+        pytest.param(
+            """
+            Parameters
+            ----------
+            a: text
+            b: text
+            """,
+            1,
+            id="failing-paragraph",
+        ),
+        pytest.param(
+            """
+            Parameters
+            ----------
+            - a
+            - b
+            """,
+            1,
+            id="failing-bullet_list",
+        ),
+    ),
+)
+def test_format_as_definition_list(docstring, n_violations, rules):
+    rules.isolate("V100")
+
+    dummy_node = DummyNode()
+
+    cleaned_docstring, column_offsets = cleandoc(docstring)
+
+    tree = parser_rst.parse(cleaned_docstring.encode())
+    context = Context("<test example>", dummy_node, column_offsets)
+
+    violations = _check_docstring(tree, context)
+
+    assert len(violations) == n_violations, format_violations(violations)

--- a/velin2/tests/test_section_rules.py
+++ b/velin2/tests/test_section_rules.py
@@ -2,36 +2,8 @@ import pytest
 
 from velin2.context import Context
 from velin2.docstring import cleandoc
-from velin2.rules import core
 from velin2.rules.core import _check_docstring, parser_rst
-
-
-class DummyNode:
-    def __init__(self):
-        self.start_point = (0, 0)
-
-
-@pytest.fixture
-def rules(monkeypatch):
-    class IsolatedRules:
-        def isolate(self, rules: str | list[str]):
-            if isinstance(rules, str):
-                rules = [rules]
-            isolated_rules = {
-                name: rule for name, rule in core.rules.items() if name in rules
-            }
-            monkeypatch.setattr(core, "rules", isolated_rules)
-
-    yield IsolatedRules()
-
-
-def format_violations(violations):
-    return "\n".join(
-        [
-            "Found the following violations:",
-            *(str(violation) for violation in violations),
-        ]
-    )
+from velin2.tests import DummyNode, format_violations
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Follow-up to #36

This adds rules to validate the `Parameters` / `Other Parameters` sections. They should run after the section rules to make sure those sections are findable.

The following rules are currently planned (numbers may change):
- [x] `V100`: the "body" of the `Parameters` section must be a definition list
- [ ] `V101`: the colon separating the term from the classifier must be preceded by a space
- [ ] `V102`: there must only be a single classifier
- [ ] `V110`: the terms must be valid python identifiers
- [ ] `V111`: variable-length parameters must be preceded by `*` / `**`
- [ ] `V112`: all named parameters must be documented
- [ ] `V113`: all documented parameters must exist in the signature (or the signature must contain variable-length parameters)
- [ ] `V120`: classifiers (when present) must follow the type spec format
- [ ] `V121`: if the parameter has a default, the type spec should end with `optional` or a default notation
- [ ] `V122`: the default notation format should be consistent for the entire project